### PR TITLE
Fix read dirs

### DIFF
--- a/src/main/Reader.ts
+++ b/src/main/Reader.ts
@@ -21,6 +21,7 @@ export class Reader {
 			".gitignore",
 		];
 		this.ignoreDir = [
+			".git",
 			"tests",
 			"vendor",
 		]
@@ -37,7 +38,12 @@ export class Reader {
 	}
 
 	private readDirectory(absolutePath: string) {
-		const files = fs.readdirSync(absolutePath, "utf-8");
+		let files: string[];
+		try {
+			files = fs.readdirSync(absolutePath, "utf-8");
+		} catch (e) {
+			throw new Error(`Cannot read dir ${absolutePath}`);
+		}
 		
 		for (const key in files) {
 			const dirName = files[key];
@@ -48,12 +54,13 @@ export class Reader {
 			let filePath = `${absolutePath}/${files[key]}`;
 			const statSync = fs.statSync(filePath);
 
-			if (statSync.isDirectory()) {
-				this.readDirectory(filePath);
-				continue;
-			}
 			const extension = path.extname(filePath);
 			if (this.isInvalidFile(extension)) {
+				continue;
+			}
+
+			if (statSync.isDirectory()) {
+				this.readDirectory(filePath);
 				continue;
 			}
 

--- a/src/main/util.ts
+++ b/src/main/util.ts
@@ -72,7 +72,7 @@ export const Workspace = {
 			return null;
 		}
 
-		const path = folder.uri.path;
+		const path = folder.uri.fsPath;
 		return fileName == undefined ? path : `${path}/${fileName}`;
 	},
 


### PR DESCRIPTION
- When running in Windows "uri.path" can produces a invalid dir name.

- Treats Errors to avoid broke the extension