### PR TITLE
Fix regex parser & View graphs on tab group

### DIFF
--- a/src/common/types/interfaces.type.ts
+++ b/src/common/types/interfaces.type.ts
@@ -1,4 +1,4 @@
-import { KeyValue } from "./general.types";
+import { RegexGroups } from "../../main/parsers/ParserFileRegex";
 import { Attribute, ClassDetail, FileMetadata, Method, Namespace, Package } from "./backend.type";
 import { Optional } from "./classes.type";
 
@@ -17,9 +17,9 @@ export interface IParserFile {
 export interface IParser<T> {
 	getPatternRegex(): string;
 
-	getValue(groups: KeyValue): Optional<T>;
+	getValue(groups: RegexGroups): Optional<T>;
 
-	hasRequiredValues(groups: KeyValue): boolean;
+	hasRequiredValues(groups: RegexGroups): boolean;
 
 	validator?: (value: T) => string[],
 }

--- a/src/front/Front.ts
+++ b/src/front/Front.ts
@@ -1,8 +1,8 @@
 import { ExtensionContext } from "vscode";
 import { ClassMetadata } from "../common/types/backend.type";
-import { NodeWebview } from "./NodeWebview";
+import { GraphWebviewFactory } from "./NodeWebview";
 
 export function runWebview(context: ExtensionContext, classMetadata: ClassMetadata) {
-	const node = NodeWebview.create(classMetadata, context);
+	const node = GraphWebviewFactory.create(classMetadata, context);
 	node.render();
 }

--- a/src/front/NodeWebview.ts
+++ b/src/front/NodeWebview.ts
@@ -1,5 +1,5 @@
 import { ExtensionContext, ViewColumn, WebviewOptions, WebviewPanel, WebviewPanelOptions, window } from "vscode";
-import { ClassMetadata } from "../common/types/backend.type";
+import { ClassDetail, ClassMetadata } from "../common/types/backend.type";
 import { MainComponent } from "./core/components/MainComponent";
 import { HtmlTemplate } from "./core/templates/HtmlTemplate";
 import { Optional } from "../common/types/classes.type";
@@ -29,10 +29,11 @@ export class NodeWebview {
 
 		this.panel = window.createWebviewPanel("uml-gen", title, ViewColumn.Beside, options);
 		this.panel.webview.onDidReceiveMessage(message => MessagesProcessor.process(message, context));
+		this.panel.onDidDispose(e => NodeWebview.delete(metadata));
 	}
 
 	public static create(metadata: ClassMetadata, context: ExtensionContext): NodeWebview {
-		const tag = `webview-${metadata.detail.name}`;
+		const tag = createWebviewTag(metadata.detail);
 		if (NodeWebview.panels[tag] == undefined) {
 			NodeWebview.panels[tag] = new NodeWebview(metadata, context);
 		}
@@ -57,6 +58,17 @@ export class NodeWebview {
 		this.panel.webview.html = template.getHtml();
 		this.panel.reveal();
 	}
+
+	private static delete(metadata: ClassMetadata): NodeWebview {
+		const tag = createWebviewTag(metadata.detail);
+		const panel = this.panels[tag];
+		delete(this.panels[tag]);
+		return panel;
+	}
+}
+
+function createWebviewTag(detail: ClassDetail): string {
+	return `webview_${detail.name}`;
 }
 
 class MessagesProcessor {

--- a/src/front/NodeWebview.ts
+++ b/src/front/NodeWebview.ts
@@ -7,47 +7,49 @@ import { parseFromPath } from "../main/parsers/ParserFactory";
 import { WindowErrors } from "../main/util";
 import { FrontMessage, FrontNode, Mesages } from "../common/types/frontend.type";
 
-type CachePanels = {
-	[key: string]: NodeWebview
+type MapNodeWebview = { [key: string]: GraphWebview }
+
+type PanelOptions = WebviewPanelOptions & WebviewOptions;
+
+type ShowOptions = ViewColumn | { 
+	readonly viewColumn: ViewColumn,
+	readonly preserveFocus?: boolean,
 }
 
-export class NodeWebview {
+const UML_PREFIX = "UML - ";
 
-	private static panels: CachePanels = { }
+class GraphWebview {
 
 	private panel: WebviewPanel;
 
-	private constructor(
+	constructor(
 		private metadata: ClassMetadata, 
-		private context: ExtensionContext
+		private context: ExtensionContext,
+		showOptions: ShowOptions
 	) {
-		const title = `UML - ${metadata.detail.name}`;
-		const options: WebviewPanelOptions & WebviewOptions = {
+		const title = `${UML_PREFIX}${metadata.detail.name}`;
+		const options: PanelOptions = {
 			enableScripts: true,
 			enableForms: true,
 		}
 
-		this.panel = window.createWebviewPanel("uml-gen", title, ViewColumn.Beside, options);
+		this.panel = window.createWebviewPanel("uml-gen", title, showOptions, options);
 		this.panel.webview.onDidReceiveMessage(message => MessagesProcessor.process(message, context));
-		this.panel.onDidDispose(e => NodeWebview.delete(metadata));
+		this.panel.onDidDispose(e => GraphWebviewFactory.delete(metadata));
 	}
 
-	public static create(metadata: ClassMetadata, context: ExtensionContext): NodeWebview {
-		const tag = createWebviewTag(metadata.detail);
-		if (NodeWebview.panels[tag] == undefined) {
-			NodeWebview.panels[tag] = new NodeWebview(metadata, context);
-		}
-		return NodeWebview.panels[tag];
+	public static create(metadata: ClassMetadata, context: ExtensionContext): GraphWebview {
+		return GraphWebviewFactory.create(metadata, context);
 	}
 
-	public static createFromPath(path: string, context: ExtensionContext): Optional<NodeWebview> {
+	public static createFromPath(path: string, context: ExtensionContext): Optional<GraphWebview> {
 		const metadata = parseFromPath(path)
 		if (metadata.value == undefined) {
 			const message = `Cannot create file from ${path}`;
-			return new Optional<NodeWebview>(undefined, [ message ]);
+			return new Optional<GraphWebview>(undefined, [ message ]);
 		}
 
-		const node = NodeWebview.create(metadata.value, context);
+		const node = GraphWebview.create(metadata.value, context);
 		return new Optional(node);
 	}
 
@@ -59,16 +61,64 @@ export class NodeWebview {
 		this.panel.reveal();
 	}
 
-	private static delete(metadata: ClassMetadata): NodeWebview {
-		const tag = createWebviewTag(metadata.detail);
-		const panel = this.panels[tag];
-		delete(this.panels[tag]);
-		return panel;
+	public reveal(viewColumn?: ViewColumn) {
+		this.panel.reveal(viewColumn)
 	}
 }
 
 function createWebviewTag(detail: ClassDetail): string {
 	return `webview_${detail.name}`;
+}
+
+export class GraphWebviewFactory {
+
+	private static self = new GraphWebviewFactory;
+
+	private mapNode: MapNodeWebview = { };
+	private lastGraph: GraphWebview | undefined; 
+
+	public static create(metadata: ClassMetadata, context: ExtensionContext): GraphWebview {
+		const self = GraphWebviewFactory.self;
+		self.lastGraph?.reveal();
+		
+		const tag = createWebviewTag(metadata.detail);
+		if (!self.hasTag(tag)) {
+			const showOptions = self.getShowOptions();
+			self.mapNode[tag] = new GraphWebview(metadata, context, showOptions);
+		}
+		
+		self.lastGraph = self.mapNode[tag];
+		return self.lastGraph;
+	}
+
+	public static delete(metadata: ClassMetadata): GraphWebview {
+		const self = GraphWebviewFactory.self;
+
+		const tag = createWebviewTag(metadata.detail);
+		const panel = self.mapNode[tag];
+		delete(self.mapNode[tag]);
+
+		self.lastGraph = self.getLastGraph();
+		return panel;
+	}
+
+	private hasTag(tag: string): boolean {
+		return this.mapNode[tag] != undefined;
+	}
+
+	private getShowOptions(): ShowOptions {
+		return this.lastGraph == undefined ? ViewColumn.Beside : ViewColumn.Active;
+	}
+
+	private getLastGraph(): GraphWebview | undefined {
+		const keys = Object.keys(this.mapNode);
+		if (keys.length == 0) {
+			return undefined;
+		}
+
+		const lastKey = keys[keys.length - 1];
+		return this.mapNode[lastKey];
+	}
 }
 
 class MessagesProcessor {
@@ -92,7 +142,7 @@ class NewNode {
 			WindowErrors.showMessage(metadata.getMessage());
 			return;
 		}
-		const panel = NodeWebview.createFromPath(node.path, context);
+		const panel = GraphWebview.createFromPath(node.path, context);
 		if (panel.value == undefined) {
 			WindowErrors.showMessage(panel.getMessage());
 			return;

--- a/src/main/Reader.ts
+++ b/src/main/Reader.ts
@@ -54,13 +54,13 @@ export class Reader {
 			let filePath = `${absolutePath}/${files[key]}`;
 			const statSync = fs.statSync(filePath);
 
-			const extension = path.extname(filePath);
-			if (this.isInvalidFile(extension)) {
+			if (statSync.isDirectory()) {
+				this.readDirectory(filePath);
 				continue;
 			}
 
-			if (statSync.isDirectory()) {
-				this.readDirectory(filePath);
+			const extension = path.extname(filePath);
+			if (this.isInvalidFile(extension)) {
 				continue;
 			}
 

--- a/src/main/parsers/ParserFileRegex.ts
+++ b/src/main/parsers/ParserFileRegex.ts
@@ -1,0 +1,65 @@
+import { Allowed, Encapsulation } from "../../common/types/encapsulation.types";
+import { KeyValue } from "../../common/types/general.types";
+import { IParserFile } from "../../common/types/interfaces.type";
+
+export class ParserFileRegex {
+
+	private regex: RegExp;
+	private currentExpression: null | RegExpExecArray;
+
+	constructor(private source: string, parser: IParserFile) {
+		const regexNamespace = parser.getNamespacePareser().getPatternRegex();
+		const regexDetail = parser.getDetailParser().getPatternRegex();
+		const regexAttribute = parser.getAttributeParser().getPatternRegex();
+		const regexMethod = parser.getMethodParser().getPatternRegex();
+		const regexImport = parser.getImportParser().getPatternRegex();
+
+		const pattern = `(${regexNamespace})|(${regexDetail})|(${regexImport})|(${regexAttribute})|(${regexMethod})`;
+
+		this.regex = new RegExp(pattern, "gi");
+		this.currentExpression = null;
+	}
+
+	public hasNextExpression(): boolean {
+		this.currentExpression = this.regex.exec(this.source);
+		return this.currentExpression != null;
+	}
+
+	public getExpression(): RegexGroups {
+		const groups = this.currentExpression?.groups;
+		return new RegexGroups(groups);
+	}
+	
+	public getCurrentSource(): string {
+		return this.regex.source;
+	}
+}
+
+export class RegexGroups {
+	constructor(private map: KeyValue | undefined) {
+	}
+
+	public has(key: string): boolean {
+		if (this.map == undefined) {
+			return false;
+		}
+		return this.map[key] != undefined;
+	}
+
+	public get(key: string, defValue: string = ""): string {
+		if (this.map == undefined) {
+			return defValue;
+		}
+		return this.map[key] ?? defValue;
+	}
+
+	public split(split: string, key: string, defValue: string = ""): string[] {
+		const value = this.get(key, defValue);
+		return value == "" ? [] : value.split(split);
+	}
+
+	public asEncapsulation(key: string): Allowed {
+		const value = this.get(key);
+		return Encapsulation.to(value);
+	}
+}

--- a/src/main/parsers/java/JavaDetailParser.ts
+++ b/src/main/parsers/java/JavaDetailParser.ts
@@ -1,16 +1,23 @@
 import { ClassDetail } from "../../../common/types/backend.type";
 import { Optional } from "../../../common/types/classes.type";
 import { Allowed } from "../../../common/types/encapsulation.types";
-import { KeyValue } from "../../../common/types/general.types";
 import { IParser } from "../../../common/types/interfaces.type";
 import { Regex } from "../../util";
+import { RegexGroups } from "../ParserFileRegex";
+
+enum Attr {
+	encap = "cls_encap",
+	details = "cls_details",
+	name = "cls_name",
+	inherit = "cls_inherit",
+}
 
 export class JavaDetailParser implements IParser<ClassDetail> {
 
 	constructor(private type: Allowed[]) { }
 
-	hasRequiredValues(groups: KeyValue): boolean {
-		return groups.cls_name != undefined;
+	hasRequiredValues(groups: RegexGroups): boolean {
+		return groups.has(Attr.name);
 	}
 
 	getPatternRegex(): string {
@@ -18,17 +25,17 @@ export class JavaDetailParser implements IParser<ClassDetail> {
 		const signature = `((static class)|(abstract class)|interface|enum|class)`;
 		const name = `[${Regex.Letters}${Regex.Numbers}]+`;
 
-		return `(?<cls_encap>${encapsulation})${Regex.BlankReq}`
-			+ `(?<cls_details>${signature})${Regex.BlankReq}`
-			+ `(?<cls_name>${name})${Regex.BlankOp}`
-			+ `(?<cls_inherit>${Regex.Anything})${Regex.OpenBlock}`;
+		return `(?<${Attr.encap}>${encapsulation})${Regex.BlankReq}`
+			+ `(?<${Attr.details}>${signature})${Regex.BlankReq}`
+			+ `(?<${Attr.name}>${name})${Regex.BlankOp}`
+			+ `(?<${Attr.inherit}>${Regex.Anything})${Regex.OpenBlock}`;
 	}
 
-	getValue(groups: KeyValue): Optional<ClassDetail> {
-		const details = groups.cls_details ?? "";
+	getValue(groups: RegexGroups): Optional<ClassDetail> {
+		const details = groups.get(Attr.details);
 
 		return new Optional({
-			name: groups.cls_name,
+			name: groups.get(Attr.name),
 			isAbstract: details.includes("abstract"),
 			isInterface: details.includes("interface"),
 			isStatic: details.includes("static"),

--- a/src/main/parsers/java/JavaImportParser.ts
+++ b/src/main/parsers/java/JavaImportParser.ts
@@ -1,33 +1,37 @@
 import { Package } from "../../../common/types/backend.type";
 import { Optional } from "../../../common/types/classes.type";
-import { KeyValue } from "../../../common/types/general.types";
 import { IPackageMapper, IParser } from "../../../common/types/interfaces.type";
 import { Regex } from "../../util";
+import { RegexGroups } from "../ParserFileRegex";
+
+enum Attrs {
+	imports = "pack_imports",
+}
 
 export class JavaImportParser implements IParser<Package> {
 
 	constructor(private mapper: IPackageMapper) {
 	}
 
-	hasRequiredValues(groups: KeyValue): boolean {
-		return groups.pack_imports != undefined;
+	hasRequiredValues(groups: RegexGroups): boolean {
+		return groups.has(Attrs.imports);
 	}
 
 	public getPatternRegex(): string {
 		const importKey = `(import)${Regex.BlankReq}`;
 		const namespaceKey = `[${Regex.Letters}_\\-\\.]+`
-		return `${importKey}(?<pack_imports>${namespaceKey});`;
+		return `${importKey}(?<${Attrs.imports}>${namespaceKey});`;
 	}
 
-	public getValue(group: KeyValue): Optional<Package> {
-		const importsPart = group.pack_imports.split(".");
+	public getValue(group: RegexGroups): Optional<Package> {
+		const importsPart = group.split(".", Attrs.imports);
 		const lastIndexPackage = importsPart.length - 1;
 		const className = importsPart[lastIndexPackage];
 
 		return new Optional({ 
 			classImported: className, 
 			file: this.mapper.getFile(importsPart),
-			package: group.pack_imports 
+			package: group.get(Attrs.imports),
 		})
 	}
 }

--- a/src/main/parsers/java/JavaNamespaceParser.ts
+++ b/src/main/parsers/java/JavaNamespaceParser.ts
@@ -1,23 +1,26 @@
 import { Namespace } from "../../../common/types/backend.type";
 import { Optional } from "../../../common/types/classes.type";
-import { KeyValue } from "../../../common/types/general.types";
 import { IParser } from "../../../common/types/interfaces.type";
 import { Regex } from "../../util";
+import { RegexGroups } from "../ParserFileRegex";
+
+enum Attrs {
+	namespace = "_namespace",
+}
 
 export class JavaNamespaceParser implements IParser<Namespace> {
 
-	hasRequiredValues(groups: KeyValue): boolean {
+	hasRequiredValues(groups: RegexGroups): boolean {
 		return true;
 	}
 
 	getPatternRegex(): string {
 		const namespace = `[${Regex.Letters}${Regex.Numbers}\.-_]+`
-		return `package${Regex.BlankReq}(?<_namespace>${namespace});`
+		return `package${Regex.BlankReq}(?<${Attrs.namespace}>${namespace});`
 	}
 
-	getValue(groups: KeyValue): Optional<Namespace> {
-		const namespace = groups._namespace ?? "";
-		const parts = namespace == "" ? [] : namespace.split(".");
+	getValue(groups: RegexGroups): Optional<Namespace> {
+		const parts = groups.split(".", Attrs.namespace);
 		return new Optional<Namespace>({ parts: parts });
 	}
 }


### PR DESCRIPTION
- Fix java's file parser that not matches a regex group. Used constants to define regex group name;

- When new graph is generated, allways is opend in splitted tab with anothers graphs;